### PR TITLE
Fix: unable to populate updates for existing clients if client-type is not specified explicitly in configuration

### DIFF
--- a/OpenIddictExternalAuthentication/Infrastructure/ClientSeeder.cs
+++ b/OpenIddictExternalAuthentication/Infrastructure/ClientSeeder.cs
@@ -47,15 +47,15 @@ public class ClientSeeder
             }
             else
             {
-                if (string.IsNullOrEmpty(client.ApplicationType))
+                if (string.IsNullOrEmpty(client.ClientType))
                 {
                     if (string.IsNullOrEmpty(client.ClientSecret))
                     {
-                        client.ApplicationType = "public";
+                        client.ClientType = "public";
                     }
                     else
                     {
-                        client.ApplicationType = "confidential";
+                        client.ClientType = "confidential";
                     }
                 }
 


### PR DESCRIPTION
During the migration to OpenIddict v6, I mistakenly used `OpenIddictApplicationDescriptor.ApplicationType` as a replacement of `OpenIddictApplicationDescriptor.Type`, when `OpenIddictApplicationDescriptor.ClientType` should've been used

docs: https://documentation.openiddict.com/guides/migration/40-to-50#use-openiddictapplicationdescriptor-clienttype-instead-of-openiddictapplicationdescriptor-type