### PR TITLE
Update to OpenIDdict v7

### DIFF
--- a/OpenIddictExternalAuthentication.Example/OpenIddictExternalAuthentication.Example.csproj
+++ b/OpenIddictExternalAuthentication.Example/OpenIddictExternalAuthentication.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <UserSecretsId>aspnet-OpenIddictExternalAuthentication.Example-EF745C35-3F8F-485A-998C-150F352981C9</UserSecretsId>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <AssemblyName>Shaddix.OpenIddict.ExternalAuthentication.Example</AssemblyName>
@@ -9,26 +9,26 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.5">
+        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.23" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.23" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.23">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.6" />
-        <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="7.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="7.0.5" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="7.0.5" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="7.0.5" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="6.0.16" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.Twitter" Version="7.0.5" />
-        <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="7.0.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.3" />
-        <PackageReference Include="Microsoft.Identity.Web" Version="3.7.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="7.0.5" />
-        <PackageReference Include="OpenIddict.AspNetCore" Version="6.1.1" />
-        <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="6.1.1" />
+        <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.22" />
+        <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="8.3.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.23" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.23" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="8.0.23" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="6.0.36" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.Twitter" Version="8.0.23" />
+        <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.23" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.23" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+        <PackageReference Include="Microsoft.Identity.Web" Version="4.3.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.23" />
+        <PackageReference Include="OpenIddict.AspNetCore" Version="7.2.0" />
+        <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="7.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/OpenIddictExternalAuthentication.Tests/OpenIddictExternalAuthentication.Tests.csproj
+++ b/OpenIddictExternalAuthentication.Tests/OpenIddictExternalAuthentication.Tests.csproj
@@ -1,20 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/OpenIddictExternalAuthentication/Infrastructure/ClientSeeder.cs
+++ b/OpenIddictExternalAuthentication/Infrastructure/ClientSeeder.cs
@@ -47,15 +47,15 @@ public class ClientSeeder
             }
             else
             {
-                if (string.IsNullOrEmpty(client.ApplicationType))
+                if (string.IsNullOrEmpty(client.ClientType))
                 {
                     if (string.IsNullOrEmpty(client.ClientSecret))
                     {
-                        client.ApplicationType = "public";
+                        client.ClientType = "public";
                     }
                     else
                     {
-                        client.ApplicationType = "confidential";
+                        client.ClientType = "confidential";
                     }
                 }
 

--- a/OpenIddictExternalAuthentication/OpenIddictExtensions.cs
+++ b/OpenIddictExternalAuthentication/OpenIddictExtensions.cs
@@ -232,7 +232,7 @@ public static class OpenIddictExtensions
         var identityServerRefreshTokenValidatorType =
             typeof(IdentityServerRefreshTokenValidator<>).MakeGenericType(settings.DbContextType);
         openIddictBuilder.Services.AddTransient(identityServerRefreshTokenValidatorType);
-        openIddictBuilder.Services.AddTransient<IExternalRefreshTokenValidator>(
+        openIddictBuilder.Services.AddTransient(
             provider =>
                 provider.GetRequiredService(identityServerRefreshTokenValidatorType)
                 as IExternalRefreshTokenValidator
@@ -246,9 +246,11 @@ public static class OpenIddictExtensions
         options.AddEventHandler<OpenIddictServerEvents.ValidateTokenContext>(builder =>
         {
             builder
-                .UseScopedHandler<
-                    IOpenIddictServerHandler<OpenIddictServerEvents.ValidateTokenContext>
-                >(s => s.GetRequiredService(validatorHandlerType))
+                .UseScopedHandler(
+                    s =>
+                        s.GetRequiredService(validatorHandlerType)
+                        as IOpenIddictServerHandler<OpenIddictServerEvents.ValidateTokenContext>
+                )
                 .SetOrder(
                     OpenIddictServerHandlers.Protection.ValidateIdentityModelToken.Descriptor.Order
                         - 100

--- a/OpenIddictExternalAuthentication/OpenIddictExternalAuthentication.csproj
+++ b/OpenIddictExternalAuthentication/OpenIddictExternalAuthentication.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageVersion>2.10.6</PackageVersion>
         <Title>Shaddix.OpenIddict.ExternalAuthentication</Title>
@@ -25,10 +25,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.0" />
-        <PackageReference Include="OpenIddict.AspNetCore" Version="6.1.1" />
-        <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="7.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.23" />
+        <PackageReference Include="OpenIddict.AspNetCore" Version="7.2.0" />
+        <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="8.0.23" />
+        <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.23" />
         <PackageReference Include="IdentityModel" Version="6.0.0" />
     </ItemGroup>
 


### PR DESCRIPTION
Done using migration guide. Nothing much changed, though.

Tests are green; also checked manually - direct & google work fine.

Guide said that a new migration is needed to catch up with recent changes, but EFC refused to create a non-empty migration for me - perhaps, SQLite's TEXT is not required to have length :)